### PR TITLE
(SIMP-1997) Migrate to the puppet_vardir fact

### DIFF
--- a/.fixtures.yml.local
+++ b/.fixtures.yml.local
@@ -1,6 +1,0 @@
---- 
-  fixtures: 
-    symlinks: 
-      simpcat: "#{source_dir}"
-      simplib: "#{source_dir}/../simplib"
-      stdlib: "#{source_dir}/../stdlib"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Nov 14 2016 Nick Miller <nick.miller@onyxpoint.com> - 6.0.1-0
+- Changed from using Puppet[:vardir] to Facter.value(:puppet_vardir), which
+  accounts for the different vardirs on agent and server.
+
 * Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0-0
 - Fully deconflict with puppetlabs-concat by renaming all types and providers
   to 'simpcat'

--- a/Gemfile
+++ b/Gemfile
@@ -1,33 +1,20 @@
 # ------------------------------------------------------------------------------
-# Environment variables:
-#   SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
-#   PUPPET_VERSION   | specifies the version of the puppet gem to load
-# ------------------------------------------------------------------------------
 # NOTE: SIMP Puppet rake tasks support ruby 2.0 and ruby 2.1
 # ------------------------------------------------------------------------------
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
   gem "rake"
-  gem 'puppet', puppetversion
+  gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~>4')
   gem "rspec", '< 3.2.0'
   gem "rspec-puppet"
   gem "hiera-puppet-helper"
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
-  gem "simp-rspec-puppet-facts", "~> 1.3"
-
-
-  # simp-rake-helpers does not suport puppet 2.7.X
-  if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
-      # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
-      # TODO: fix upstream deps (parallel in simp-rake-helpers)
-      RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
-    gem 'simp-rake-helpers'
-  end
+  gem "simp-rspec-puppet-facts", ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 1.3')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 3')
 end
 
 group :development do
@@ -47,5 +34,5 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', '>= 1.0.5'
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.5')
 end

--- a/lib/puppet/parser/functions/simpcat_output.rb
+++ b/lib/puppet/parser/functions/simpcat_output.rb
@@ -1,5 +1,10 @@
 module Puppet::Parser::Functions
     newfunction(:simpcat_output, :type => :rvalue, :doc => "Returns the output file for a given SIMP concat build.") do |args|
-        "#{Puppet[:vardir]}/simpcat/output/#{Array(args).flatten.first}.out"
+      puppet_vardir = lookupvar('puppet_vardir')
+      if puppet_vardir.nil? || puppet_vardir.strip.empty?
+        raise(Puppet::ParseError, 'Could not determine a valid Puppet vardir on the client')
+      end
+
+        "#{puppet_vardir}/simpcat/output/#{Array(args).flatten.first}.out"
     end
 end

--- a/lib/puppet/provider/simpcat_build/build.rb
+++ b/lib/puppet/provider/simpcat_build/build.rb
@@ -4,7 +4,7 @@ Puppet::Type.type(:simpcat_build ).provide :simpcat_build do
   desc "simpcat_build provider"
 
   def build_file(f_base)
-    if File.directory?("#{Puppet[:vardir]}/simpcat/fragments/#{@resource[:name]}") then
+    if File.directory?("#{Facter.value(:puppet_vardir)}/simpcat/fragments/#{@resource[:name]}") then
       File.exist?("#{f_base}.out") and FileUtils.mv("#{f_base}.out","#{f_base}.prev")
 
       if not File.directory?(File.dirname(f_base)) then
@@ -13,7 +13,7 @@ Puppet::Type.type(:simpcat_build ).provide :simpcat_build do
 
       outfile = File.open("#{f_base}.out", "w+")
       input_lines = Array.new
-      Dir.chdir("#{Puppet[:vardir]}/simpcat/fragments/#{@resource[:name]}") do
+      Dir.chdir("#{Facter.value(:puppet_vardir)}/simpcat/fragments/#{@resource[:name]}") do
         # Clean up anything that shouldn't be here.
 
         if File.exist?('.~simpcat_fragments') then
@@ -99,7 +99,7 @@ Puppet::Type.type(:simpcat_build ).provide :simpcat_build do
 
       outfile.close
     elsif not @resource[:quiet] then
-      fail Puppet::Error,"The fragments directory at '#{Puppet[:vardir]}/simpcat/fragments/#{@resource[:name]}' does not exist!"
+      fail Puppet::Error,"The fragments directory at '#{Facter.value(:puppet_vardir)}/simpcat/fragments/#{@resource[:name]}' does not exist!"
     end
   end
 
@@ -153,8 +153,8 @@ Puppet::Type.type(:simpcat_build ).provide :simpcat_build do
   def sync_file
     begin
       if @resource[:target] and check_onlyif then
-        debug "Copying #{Puppet[:vardir]}/simpcat/output/#{@resource[:name]}.out to #{@resource[:target]}"
-        FileUtils.cp("#{Puppet[:vardir]}/simpcat/output/#{@resource[:name]}.out", @resource[:target])
+        debug "Copying #{Facter.value(:puppet_vardir)}/simpcat/output/#{@resource[:name]}.out to #{@resource[:target]}"
+        FileUtils.cp("#{Facter.value(:puppet_vardir)}/simpcat/output/#{@resource[:name]}.out", @resource[:target])
       elsif @resource[:target] then
         debug "Not copying to #{@resource[:target]}, 'onlyif' check failed"
       elsif @resource[:onlyif] then
@@ -169,7 +169,7 @@ Puppet::Type.type(:simpcat_build ).provide :simpcat_build do
     begin
       if @resource[:parent_build] then
         Array(@resource[:parent_build]).flatten.each do |parent_build|
-          if "#{Puppet[:vardir]}/simpcat/fragments/#{parent_build}".eql?(File.dirname(@resource[:target])) then
+          if "#{Facter.value(:puppet_vardir)}/simpcat/fragments/#{parent_build}".eql?(File.dirname(@resource[:target])) then
             FileUtils.mkdir_p(File.dirname(@resource[:target]))
 
             frags_record = "#{File.dirname(@resource[:target])}/.~simpcat_fragments"

--- a/lib/puppet/provider/simpcat_fragment/fragment.rb
+++ b/lib/puppet/provider/simpcat_fragment/fragment.rb
@@ -7,9 +7,9 @@ Puppet::Type.type(:simpcat_fragment).provide :simpcat_fragment do
 
     begin
       if @resource[:externally_managed] == :true then
-        FileUtils.touch("#{Puppet[:vardir]}/simpcat/fragments/#{@resource[:group]}/#{@resource[:fragment]}")
+        FileUtils.touch("#{Facter.value(:puppet_vardir)}/simpcat/fragments/#{@resource[:group]}/#{@resource[:fragment]}")
       else
-        fh = File.open("#{Puppet[:vardir]}/simpcat/fragments/#{@resource[:group]}/#{@resource[:fragment]}", "w")
+        fh = File.open("#{Facter.value(:puppet_vardir)}/simpcat/fragments/#{@resource[:group]}/#{@resource[:fragment]}", "w")
         fh.puts @resource[:content]
         fh.close
       end
@@ -21,9 +21,9 @@ Puppet::Type.type(:simpcat_fragment).provide :simpcat_fragment do
 
   def register
     begin
-      FileUtils.mkdir_p("#{Puppet[:vardir]}/simpcat/fragments/#{@resource[:group]}")
+      FileUtils.mkdir_p("#{Facter.value(:puppet_vardir)}/simpcat/fragments/#{@resource[:group]}")
 
-      frags_record = "#{Puppet[:vardir]}/simpcat/fragments/#{@resource[:group]}/.~simpcat_fragments"
+      frags_record = "#{Facter.value(:puppet_vardir)}/simpcat/fragments/#{@resource[:group]}/.~simpcat_fragments"
       fh = File.open(frags_record,'a')
       fh.puts(@resource[:fragment])
       fh.close

--- a/lib/puppet/type/simpcat_build.rb
+++ b/lib/puppet/type/simpcat_build.rb
@@ -143,7 +143,7 @@ Puppet::Type.newtype(:simpcat_build) do
     def insync?(is)
       provider.register
 
-      f_base = "#{Puppet[:vardir]}/simpcat/output/#{@resource[:name]}"
+      f_base = "#{Facter.value(:puppet_vardir)}/simpcat/output/#{@resource[:name]}"
 
       provider.build_file(f_base)
 
@@ -195,13 +195,13 @@ Puppet::Type.newtype(:simpcat_build) do
     # in the catalog.
     #
     # Otherwise, clean up the fragment space in case some have changed names.
-    if resource.empty? and File.directory?("#{Puppet[:vardir]}/simpcat/fragments/#{self[:name]}") then
-      debug "Removing: #{Puppet[:vardir]}/simpcat/fragments/#{self[:name]}"
-      FileUtils.rm_rf("#{Puppet[:vardir]}/simpcat/fragments/#{self[:name]}")
+    if resource.empty? and File.directory?("#{Facter.value(:puppet_vardir)}/simpcat/fragments/#{self[:name]}") then
+      debug "Removing: #{Facter.value(:puppet_vardir)}/simpcat/fragments/#{self[:name]}"
+      FileUtils.rm_rf("#{Facter.value(:puppet_vardir)}/simpcat/fragments/#{self[:name]}")
     else
-      (Dir.glob("#{Puppet[:vardir]}/simpcat/fragments/#{self[:name]}/*").map{|x| File.basename(x)} - req.map{|x| x[:name].split('+')[1..-1].join('+')}).each do |todel|
-        debug "Removing: #{Puppet[:vardir]}/simpcat/fragments/#{self[:name]}/#{todel}"
-        FileUtils.rm_f("#{Puppet[:vardir]}/simpcat/fragments/#{self[:name]}/#{todel}")
+      (Dir.glob("#{Facter.value(:puppet_vardir)}/simpcat/fragments/#{self[:name]}/*").map{|x| File.basename(x)} - req.map{|x| x[:name].split('+')[1..-1].join('+')}).each do |todel|
+        debug "Removing: #{Facter.value(:puppet_vardir)}/simpcat/fragments/#{self[:name]}/#{todel}"
+        FileUtils.rm_f("#{Facter.value(:puppet_vardir)}/simpcat/fragments/#{self[:name]}/#{todel}")
       end
     end
     if self[:parent_build] then
@@ -218,10 +218,10 @@ Puppet::Type.newtype(:simpcat_build) do
           warning "No simpcat_build found for parent_build #{parent_build}"
         end
 
-        if File.dirname(self[:target]).eql?("#{Puppet[:vardir]}/simpcat/fragments/#{parent_build}")
+        if File.dirname(self[:target]).eql?("#{Facter.value(:puppet_vardir)}/simpcat/fragments/#{parent_build}")
           found_parent_target = true
         elsif not self[:quiet] then
-          warning "Target dirname = #{File.dirname(self[:target])}, parent dir = #{Puppet[:vardir]}/simpcat/fragments/#{parent_build}"
+          warning "Target dirname = #{File.dirname(self[:target])}, parent dir = #{Facter.value(:puppet_vardir)}/simpcat/fragments/#{parent_build}"
         end
         # frags contains all simpcat_fragment resources for the parent simpcat_build
         frags = catalog.resources.find_all { |r| r.is_a?(Puppet::Type.type(:simpcat_fragment)) and r[:name] =~ /^#{parent_build}\+\w/ }
@@ -233,7 +233,7 @@ Puppet::Type.newtype(:simpcat_build) do
         err "No simpcat_build found for any of #{Array(self[:parent_build]).join(",")}"
       end
       if not found_parent_target then
-        err "Target directory is not #{Puppet[:vardir]}/simpcat/fragments/<parent>"
+        err "Target directory is not #{Facter.value(:puppet_vardir)}/simpcat/fragments/<parent>"
       end
     end
     req.flatten!

--- a/lib/puppet/type/simpcat_fragment.rb
+++ b/lib/puppet/type/simpcat_fragment.rb
@@ -46,7 +46,7 @@ Puppet::Type.newtype(:simpcat_fragment) do
     def insync?(is)
       provider.register
 
-      file = "#{Puppet[:vardir]}/simpcat/fragments/#{resource[:group]}/#{resource[:fragment]}"
+      file = "#{Facter.value(:puppet_vardir)}/simpcat/fragments/#{resource[:group]}/#{resource[:fragment]}"
       return false unless File.exist?(file)
 
       if resource[:content] == '!!simpcat_fragment_undef_content' then

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-simpcat",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "author":  "SIMP Team",
   "summary": "Builds files from fragments",
   "license": "Apache-2.0",


### PR DESCRIPTION
Previously, this module relied on Puppet[:vardir] to place it's temp
files. Now, with Puppet 4, that location varies depending on if the code
is being run on the client or the server. The puppet_vardir fact is more
reliable and reports the correct place in all contexts.

SIMP-1997 #close